### PR TITLE
Legg til optional uuid felt i opprett oppgave request

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
  
 Klient for å hent og opprette oppgaver i gosys
 
-Se oppgavehåntering sin [swagger](https://oppgave.dev.adeo.no/#/Oppgave/opprettOppgave) for mer info.
+Se oppgavehåntering sin [swagger](https://oppgave.intern.dev.nav.no/#/Oppgave/opprettOppgave) for mer info.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 group=no.nav.helsearbeidsgiver
-version=0.2.1
+version=0.2.2
 
 # Plugin versions
 kotlinVersion=2.2.20

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/oppgave/domain/Oppgave.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/oppgave/domain/Oppgave.kt
@@ -1,11 +1,13 @@
-@file:UseSerializers(LocalDateSerializer::class)
+@file:UseSerializers(LocalDateSerializer::class, UuidSerializer::class)
 
 package no.nav.helsearbeidsgiver.oppgave.domain
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
+import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import java.time.LocalDate
+import java.util.UUID
 
 @Serializable
 data class Oppgave(
@@ -46,6 +48,7 @@ data class OpprettOppgaveRequest(
     val aktivDato: LocalDate,
     val fristFerdigstillelse: LocalDate? = null,
     val prioritet: Prioritet,
+    val uuid: UUID? = null,
 )
 
 @Serializable


### PR DESCRIPTION
Oppgave requesten har et optional uuid felt som kan brukes for å hindre duplikate oppgaver etter ønske fra [speilvendt](https://nav-it.slack.com/archives/CSMN6320N/p1772624723869869).
I dag så har vi løst dette ved å først gjøre et get kall før vi oppretter oppgaven.
Usikker om det vits for oss å bytt til dette siden oppgave flyten kanskje skal forsvinne fra oss på sikt.